### PR TITLE
let ngen build steps handle cpp test lib

### DIFF
--- a/.github/action_templates/build-and-push/action.yaml
+++ b/.github/action_templates/build-and-push/action.yaml
@@ -41,6 +41,7 @@ runs:
         tags: |
           awiciroh/${{ inputs.image-name}}:latest
         builder: mybuilder
+        no-cache: true
       env:
         DOCKER_BUILDKIT: 1
         DOCKER_CLI_EXPERIMENTAL: enabled

--- a/docker/Dockerfile.ngen
+++ b/docker/Dockerfile.ngen
@@ -153,7 +153,7 @@ RUN cd ${WORKDIR}/ngen \
     && ln -s $(if [ "${BUILD_NGEN_PARALLEL}" == "true" ]; then echo "cmake_build_parallel"; else echo "cmake_build_serial"; fi) cmake_build \
     # Build the required submodules/external libs needed for running the tests later \
     # C++ functionality isn't separate, so always build the test_bmi_cpp shared lib (also needed for test_bmi_multi) \
-    && ./build_sub extern/test_bmi_cpp \
+    # && ./build_sub extern/test_bmi_cpp \
     # For the external language BMI integrations, conditionally build the test packages/libraries and run tests \
     &&  if [ "${NGEN_ACTIVATE_C}" == "ON" ]; then \
             ./build_sub extern/test_bmi_c; \

--- a/docker/Dockerfile.ngen-deps
+++ b/docker/Dockerfile.ngen-deps
@@ -301,7 +301,7 @@ RUN pip3 install --upgrade pip \
     && git submodule update --init --recursive \
     && python3 -m pip install -r requirements-build.txt \
     && pip3 install . \
-    && pip3 install numpy pandas pyyaml bmipy Cython netCDF4 wheel packaging \
+    && pip3 install numpy pandas pyyaml bmipy Cython netCDF4==1.6.3 wheel packaging \
     && HDF5_DIR=/usr pip3 install -v --no-build-isolation tables \
     # Make aliases for convenience \
     && alias pip='pip3' \

--- a/docker/Dockerfile.ngen-deps
+++ b/docker/Dockerfile.ngen-deps
@@ -301,7 +301,7 @@ RUN pip3 install --upgrade pip \
     && git submodule update --init --recursive \
     && python3 -m pip install -r requirements-build.txt \
     && pip3 install . \
-    && pip3 install numpy pandas pyyaml bmipy Cython netCDF4==1.6.3 wheel packaging \
+    && pip3 install numpy pandas pyyaml bmipy Cython==3.0.3 netCDF4==1.6.3 wheel packaging \
     && HDF5_DIR=/usr pip3 install -v --no-build-isolation tables \
     # Make aliases for convenience \
     && alias pip='pip3' \


### PR DESCRIPTION
ngen's cmake/test build steps should not handle building the test_cpp subdirectory/library.