### PR TITLE
Configure then build serial and parallel

### DIFF
--- a/docker/Dockerfile.ngen
+++ b/docker/Dockerfile.ngen
@@ -133,6 +133,7 @@ RUN cd ${WORKDIR}/ngen \
         -DNETCDF_LIBRARY=/usr/lib/libnetcdf.so \
         -DNETCDF_CXX_INCLUDE_DIR=/usr/local/include \
         -DNETCDF_CXX_LIBRARY=/usr/local/lib64/libnetcdf-cxx4.so ; \
+        cmake --build $cmake_build_serial --target all -j $(nproc); \
     fi \
     && if [ "${BUILD_NGEN_PARALLEL}" == "true" ]; then \
         cmake -B cmake_build_parallel -S . \
@@ -149,8 +150,8 @@ RUN cd ${WORKDIR}/ngen \
         -DNETCDF_LIBRARY=/usr/lib/libnetcdf.so \
         -DNETCDF_CXX_INCLUDE_DIR=/usr/local/include \
         -DNETCDF_CXX_LIBRARY=/usr/local/lib64/libnetcdf-cxx4.so ; \
+        cmake --build $cmake_build_parallel --target all -j $(nproc);
     fi \
-    && ln -s $(if [ "${BUILD_NGEN_PARALLEL}" == "true" ]; then echo "cmake_build_parallel"; else echo "cmake_build_serial"; fi) cmake_build \
     # Build the required submodules/external libs needed for running the tests later \
     # C++ functionality isn't separate, so always build the test_bmi_cpp shared lib (also needed for test_bmi_multi) \
     # && ./build_sub extern/test_bmi_cpp \
@@ -161,8 +162,6 @@ RUN cd ${WORKDIR}/ngen \
     &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \
             ./build_sub extern/test_bmi_fortran; \
         fi \
-    &&  for BUILD_DIR in $(if [ "${BUILD_NGEN_PARALLEL}" == "true" ]; then echo "cmake_build_parallel"; fi) $(if [ "${BUILD_NGEN_SERIAL}" == "true" ]; then echo "cmake_build_serial"; fi) ; do \
-        cmake --build $BUILD_DIR --target all -j $(nproc); \
     done \
     # run the serial tests \
     && cd ${WORKDIR}/ngen \


### PR DESCRIPTION
Fixes #50 by configuring and then immediately building the configured targets before attempting a new configuration and build.