### PR TITLE
Potential path towards addressing #49

### DIFF
--- a/.github/action_templates/build/aciton.yaml
+++ b/.github/action_templates/build/aciton.yaml
@@ -1,0 +1,35 @@
+name: build and push template
+description: "A template to build and push docker image based on provided inputs"
+# TODO reuse these in the build-and-push action
+inputs:
+  image-name:
+    description: 'image name to be built'
+    required: true
+  dockerfile-name:
+    description: 'The name of dockerfile to use'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    
+    - name: Create Cache and Builder for Buildx
+      shell: bash
+      run: |
+          docker buildx create --use --name mybuilder --node mybuilder
+
+    - name: Build and Cache Docker Image
+      uses: docker/build-push-action@v2
+      with:
+        context: ./docker
+        file: ./docker/${{ inputs.dockerfile-name}}
+        push: false
+        platforms: linux/arm64
+        tags: |
+          awiciroh/${{ inputs.image-name}}:latest
+        builder: mybuilder
+      env:
+        DOCKER_BUILDKIT: 1
+        DOCKER_CLI_EXPERIMENTAL: enabled

--- a/.github/workflows/docker_build_ngen.yml
+++ b/.github/workflows/docker_build_ngen.yml
@@ -3,19 +3,91 @@ on:
   pull_request:
     branches: [ main, notreal ]
     paths: 
-      - 'docker/Dockerfile.ngen'
-      - 'docker/Dockerfile.ngen-deps'
+      - 'docker/**'
   workflow_dispatch:
 
 jobs:
-  build:
+  changes:
+    runs-on: self-hosted
+    outputs:
+      deps: ${{ steps.changes.outputs.deps }}
+      ngen: ${{ steps.changes.outputs.ngen }}
+      troute: ${{ steps.changes.outputs.troute }}
+      ngiab: ${{ steps.changes.outputs.ngiab }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          deps:
+            - 'docker/Dockerfile.ngen-deps'
+          ngen:
+            - 'docker/Dockerfile.ngen'
+          troute:
+            - 'docker/Dockerfile.t-route'
+          ngiab:
+            - 'docker/Dockerfile'        
+
+  deps:
+    #if the ngen-deps dockerfile changes, test its build
+    needs: changes
+    if: ${{ needs.changes.outputs.deps == 'true' }}
+    runs-on: self-hosted
+    # For pull requests, it's not necessary to checkout code
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Build ngen-deps Docker image
+        uses: ./.github/action_templates/build
+        with:
+          image-name: "deps"
+          dockerfile-name: "Dockerfile.ngen-deps"
+
+  ngen:
+    #if ngen or ngen-deps dockerfile has changed, test the ngen build
+    needs: changes
+    if: ${{ needs.changes.outputs.ngen == 'true' || needs.changes.outputs.deps == 'true' }}
     runs-on: self-hosted
     # For pull requests, it's not necessary to checkout code
     permissions:
       pull-requests: read
     steps:
       - name: Build ngen Docker image
-        uses: ./.github/action_templates/build-and-push
+        uses: ./.github/action_templates/build
         with:
           image-name: "ngen"
-          dockerfile-name: "Dockerfile.ngen"      
+          dockerfile-name: "Dockerfile.ngen"
+  
+  troute:
+    #if troute dockerfile or the ngen-deps file has changed, test the troute build
+    needs: changes
+    if: ${{ needs.changes.outputs.troute == 'true' || needs.changes.outputs.deps == 'true' }}
+    runs-on: self-hosted
+    # For pull requests, it's not necessary to checkout code
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Build troute Docker image
+        uses: ./.github/action_templates/build
+        with:
+          image-name: "troute"
+          dockerfile-name: "Dockerfile.t-route"
+
+  ngiab:
+    #if any of the other docker files have changed, test the ngiab build as well
+    needs: changes
+    if: |
+      needs.changes.outputs.ngiab == 'true' || needs.changes.outputs.ngen == 'true' ||
+      needs.changes.outputs.deps == 'true' || needs.changes.outputs.troute == 'true'
+
+    runs-on: self-hosted
+    # For pull requests, it's not necessary to checkout code
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Build ngiab Docker image
+        uses: ./.github/action_templates/build
+        with:
+          image-name: "ngiab"
+          dockerfile-name: "Dockerfile.ngiab"

--- a/.github/workflows/docker_build_ngen.yml
+++ b/.github/workflows/docker_build_ngen.yml
@@ -1,0 +1,21 @@
+name: Build and push ngen image
+on:
+  pull_request:
+    branches: [ main, notreal ]
+    paths: 
+      - 'docker/Dockerfile.ngen'
+      - 'docker/Dockerfile.ngen-deps'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    # For pull requests, it's not necessary to checkout code
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Build ngen Docker image
+        uses: ./.github/action_templates/build-and-push
+        with:
+          image-name: "ngen"
+          dockerfile-name: "Dockerfile.ngen"      


### PR DESCRIPTION
I separated the build and push action after assuming that some contention existed in apply the push component on each PR.  This new action and workflow will only attempt to build (but not publish/push) the ngen dockerfile when either the `Dockerfile.ngen` or `Dockerfile.ngen-deps` is changed in a PR.  This may need a little additonal testing/refactoring, but I'm trying to understand what the base need is and how to get some validation of proposed changes running on relevant PRs to check if the changes fix and/or break the build used in the rest of the CD pipeline.

Does this start getting to that problem?