### PR TITLE
Fix syntax error

### DIFF
--- a/docker/Dockerfile.ngen
+++ b/docker/Dockerfile.ngen
@@ -162,7 +162,6 @@ RUN cd ${WORKDIR}/ngen \
     &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \
             ./build_sub extern/test_bmi_fortran; \
         fi \
-    done \
     # run the serial tests \
     && cd ${WORKDIR}/ngen \
     # && cmake --build cmake_build_serial --target test \ 


### PR DESCRIPTION
A syntax error snuck in in #51 when the build type loop was removed.  This should fix that (also a good reason why something like #49 and #53 would be extremely helpful in catching these kinds of errors before they propagate into the full CI/CD workflow and pipeline.