### PR TITLE
build wheel for new troute sub package

### DIFF
--- a/docker/Dockerfile.t-route
+++ b/docker/Dockerfile.t-route
@@ -50,6 +50,9 @@ RUN cp -s /usr/bin/python3 /usr/bin/python \
     && cd ../troute-routing \
     && python3 setup.py --use-cython bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
+    && cd ../troute-config \
+    && python3 setup.py --use-cython bdist_wheel \
+    && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
     && cd ../troute-nwm \
     && python3 setup.py bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ 


### PR DESCRIPTION
Fix t-route image to build a newly added subpackage wheel and copy it into the python environment.