### PR TITLE
Auto Mode option for ngen-datastream

### DIFF
--- a/docker/HelloNGEN.sh
+++ b/docker/HelloNGEN.sh
@@ -49,6 +49,21 @@ generate_partition() {
   /dmod/bin/partitionGenerator "$1" "$2" "partitions_$3.json" "$3" '' ''
 }
 
+if [ "$2" == "auto" ]
+  then
+    echo "AUTO MODE ENGAGED"
+    echo "Running NextGen model framework in parallel mode"
+    procs=$(nproc)
+    procs=2 # Temporary fixed value, remove for full utilization
+    generate_partition "$selected_catchment" "$selected_nexus" "$procs"
+    mpirun -n $procs /dmod/bin/ngen-parallel $selected_catchment all $selected_nexus all $selected_realization $(pwd)/partitions_$procs.json
+    echo "Run completed successfully, exiting, have a nice day!"
+    exit 0
+  else
+    echo "Entering Interactive Mode"
+    continue
+fi
+
 echo -e "${YELLOW}Select an option (type a number): ${RESET}"
 options=("Run NextGen model framework in serial mode" "Run NextGen model framework in parallel mode" "Run Bash shell" "Exit")
 select option in "${options[@]}"; do


### PR DESCRIPTION
Just adding in a quick 2nd arg function to allow the user to just feed it a data set and have it process that.

Set second arg to "auto" t engage

leans on the auto_select_file function to get the 3 args, then pushes through the run and exits

Assumptions: 
we only feed it a compliant RUN_PACKAGE that's got the 3 arg files, no additional random realization files etc.
parallel mode will be ideal for most Auto Mode use cases 
no runtime subsetting
