### PR TITLE
Clarify the meaning of `remote` when giving NGen image run options

### DIFF
--- a/guide.sh
+++ b/guide.sh
@@ -160,14 +160,14 @@ fi
 
 # Model run options
 echo -e "${UYellow}Select an option (type a number): ${Color_Off}"
-options=("Run NextGen Model using local docker image" "Run Nextgen using remote docker image" "Exit")
+options=("Run NextGen using existing local docker image" "Run NextGen after updating to latest docker image" "Exit")
 select option in "${options[@]}"; do
     case $option in
-        "Run NextGen Model using local docker image")
+        "Run NextGen using existing local docker image")
             echo "running the model"
             break
             ;;
-        "Run Nextgen using remote docker image")
+        "Run NextGen after updating to latest docker image")
             echo "pulling container and running the model"
             docker pull $IMAGE_NAME
             break
@@ -176,7 +176,7 @@ select option in "${options[@]}"; do
             echo "Have a nice day!"
             exit 0
             ;;
-        *) echo "Invalid option $REPLY, 1 to continue and 2 to exit"
+        *) echo "Invalid option $REPLY, 1 to continue with existing local image, 2 to update and run, and 3 to exit"
             ;;
     esac
 done


### PR DESCRIPTION
### TL;DR
This fixes confusing language in the guide script. Please feel free to suggest something better. 

### More detail
The guide script has a prompt to give the user the option to run with an existing container or to pull a 'fresh' version from the docker repository. 

This commit changes the language in that prompt from a somewhat confusing: 
```
1) Run NextGen Model using local docker image
2) Run Nextgen using remote docker image
3) Exit
```
(aren't all docker images local? what am I getting in a remote image?)

... to the (hopefully) more clear:
```
1) Run NextGen using existing local docker image	      
2) Run NextGen after updating to latest docker image
3) Exit
```

The idea is that the #1 "local" run does not go recompile or rebuild anything, so it might be the best option if you have a setup that is working and you simply want to re-run to reproduce a result (or see a new result from a slightly modified ngen realization, etc.) The #2 "remote" option goes to dockerhub and grabs the latest updates -- useful if you are having problems or trying to test out recently released functionality.

(*Note* -- changed "NextGen Model" to just "NextGen" to reflect the standard language.)