### PR TITLE
t-route build is broken due to recent changes.

### DIFF
--- a/docker/Dockerfile.t-route
+++ b/docker/Dockerfile.t-route
@@ -3,7 +3,7 @@
 ################################################################################################################
 ARG TROUTE_REPO_URL=https://github.com/NOAA-OWP/t-route.git \
     TROUTE_BRANCH=master \
-    TROUTE_COMMIT \
+    TROUTE_COMMIT=59a6041 \
     WORKDIR=/ngen \
     TAG_NAME
 


### PR DESCRIPTION
The [issue](https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/203) was filed due to this error.
For now, we need to use the latest working commit until the fix is provided.