### PR TITLE
use build for troute-nwm

### DIFF
--- a/docker/Dockerfile.t-route
+++ b/docker/Dockerfile.t-route
@@ -60,3 +60,4 @@ RUN cp -s /usr/bin/python3 /usr/bin/python \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ 
 
 RUN rm /usr/bin/python
+

--- a/docker/Dockerfile.t-route
+++ b/docker/Dockerfile.t-route
@@ -56,7 +56,7 @@ RUN cp -s /usr/bin/python3 /usr/bin/python \
     && python3 -m build . \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
     && cd ../troute-nwm \
-    && python3 setup.py bdist_wheel \
+    && python3 -m build . \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ 
 
 RUN rm /usr/bin/python


### PR DESCRIPTION
This is due to setup.py being deleted in the [this commit](https://github.com/NOAA-OWP/t-route/commit/41b6983dce41e15f41a3a8e24ee5ab38f1fd161b).
