### PR TITLE
fix uv install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,6 +165,7 @@ COPY --from=troute_build /ngen/t-route/src/troute-*/dist/*.whl /tmp/
 
 RUN ln -s /dmod/bin/ngen /usr/local/bin/ngen
 
+ENV UV_INSTALL_DIR=/root/.cargo/bin
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN uv self update && uv venv && \


### PR DESCRIPTION
Unfortunate timing really, they changed the default install folder a few hours ago, which breaks the non-interactive installation 
Setting this environment variable back to the old install directory fixed it

https://github.com/astral-sh/uv/releases/tag/0.5.0 breaking change to the install root