### PR TITLE
fix missing pet.so

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -123,8 +123,9 @@ RUN cmake -G Ninja -B cmake_build_parallel -S . ${COMMON_BUILD_ARGS} ${MPI_BUILD
 FROM ngen_build AS restructure_files
 # Setup final directories and permissions
 RUN mkdir -p /dmod/datasets /dmod/datasets/static /dmod/shared_libs /dmod/bin && \
-    cp -a ./extern/*/cmake_build/*.so* /dmod/shared_libs/. || true && \
-    find ./extern/noah-owp-modular -type f -iname "*.TBL" -exec cp '{}' /dmod/datasets/static \; && \
+    shopt -s globstar && \
+    cp -a ./extern/**/cmake_build/*.so* /dmod/shared_libs/. || true && \
+    cp -a ./extern/noah-owp-modular/**/*.TBL /dmod/datasets/static && \
     cp -a ./cmake_build_parallel/ngen /dmod/bin/ngen-parallel || true && \
     cp -a ./cmake_build_serial/ngen /dmod/bin/ngen-serial || true && \
     cp -a ./cmake_build_parallel/partitionGenerator /dmod/bin/partitionGenerator || true && \


### PR DESCRIPTION
fixes #248 

`shopt -s globstar` enables the `/**/` recursive directory glob wildcard

I also updated the find command to use it. The result is the same it's just a bit easier to read imo.