### PR TITLE
add ngiab version to bash prompt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -197,4 +197,6 @@ ENV PATH="/ngen/.venv/bin:${PATH}"
 COPY --from=troute_build /tmp/troute_url /ngen/troute_url
 COPY --from=ngen_build /tmp/ngen_url /ngen/ngen_url
 
+RUN echo "export PS1='\u\[\033[01;32m\]@ngiab_dev\[\033[00m\]:\[\033[01;35m\]\W\[\033[00m\]\$ '" >> ~/.bashrc
+
 ENTRYPOINT ["./HelloNGEN.sh"]


### PR DESCRIPTION
Updates the bash prompt inside the container to contain the version number.
![image](https://github.com/user-attachments/assets/c44ca2c4-f396-4e05-b49f-f6fa36488dd4)

The line in the dockerfile updates it to say `ngiab_dev`
**The github actions also needs something like this** `run: sed -i "s/@ngiab_dev/@ngiab_$(echo ${{ github.event.release.tag_name }} | sed 's/\./\\./g')/g" ./docker/Dockerfile` to make it add the version number on release.
That sed command is [what I use with the test CI I have](https://github.com/JoshCu/NGIAB-CloudInfra/blob/c710a0aa43cb143d8fae2800b19a4fdaa14d310b/.github/workflows/build-and-push.yml#L23) but that action only runs on release,  I'm not sure where that would fit into the CI in this repo. 

It's only displayed to users if they exit the HelloNgen script into the bash shell of the container, but I've found it handy to keep track of things when I'm testing stuff.
