### PR TITLE
add empirical model to ngiab

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -194,7 +194,7 @@ RUN uv pip install numpy==$(/dmod/bin/ngen --info | grep -e 'NumPy Version: ' | 
 # we can add the venv to the path so ngen can find it
 ENV PATH="/ngen/.venv/bin:${PATH}"
 
-# Install lstm
+# Install lstm - the extra index url installs cpu-only pytorch which is ~6gb smaller
 COPY --from=ngen_clone /ngen/ngen/extern/lstm/lstm /ngen/ngen/extern/lstm
 RUN uv pip install --no-cache-dir /ngen/ngen/extern/lstm --extra-index-url https://download.pytorch.org/whl/cpu
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM rockylinux:9.1 AS base
 ENV TROUTE_REPO=CIROH-UA/t-route
 ENV TROUTE_BRANCH=datastream
 ENV NGEN_REPO=CIROH-UA/ngen
-ENV NGEN_BRANCH=main
+ENV NGEN_BRANCH=ngiab
 
 # Install system dependencies
 RUN echo "max_parallel_downloads=10" >> /etc/dnf/dnf.conf
@@ -193,6 +193,10 @@ RUN uv pip install numpy==$(/dmod/bin/ngen --info | grep -e 'NumPy Version: ' | 
 # now that the only version of numpy is the one that NGen expects, 
 # we can add the venv to the path so ngen can find it
 ENV PATH="/ngen/.venv/bin:${PATH}"
+
+# Install lstm
+COPY --from=ngen_clone /ngen/ngen/extern/lstm/lstm /ngen/ngen/extern/lstm
+RUN uv pip install --no-cache-dir /ngen/ngen/extern/lstm --extra-index-url https://download.pytorch.org/whl/cpu
 
 ## add some metadata to the image
 COPY --from=troute_build /tmp/troute_url /ngen/troute_url

--- a/docker/HelloNGEN.sh
+++ b/docker/HelloNGEN.sh
@@ -80,9 +80,9 @@ select option in "${options[@]}"; do
   case $option in
     "Run NextGen model framework in serial mode"|"Run NextGen model framework in parallel mode")
       echo -e "\n"
-      n1=${selected_catchment:-$(read -p "Enter the hydrofabric catchment file path: " n1; echo "$n1")}
-      n2=${selected_nexus:-$(read -p "Enter the hydrofabric nexus file path: " n2; echo "$n2")}
-      n3=${selected_realization:-$(read -p "Enter the Realization file path: " n3; echo "$n3")}
+      n1=${selected_catchment:-$(read -erp "Enter the hydrofabric catchment file path: " n1; echo "$n1")}
+      n2=${selected_nexus:-$(read -erp "Enter the hydrofabric nexus file path: " n2; echo "$n2")}
+      n3=${selected_realization:-$(read -erp "Enter the Realization file path: " n3; echo "$n3")}
 
       echo -e "${GREEN}Selected files:\nCatchment: $n1\nNexus: $n2\nRealization: $n3${RESET}\n"
 


### PR DESCRIPTION
uses the new [ngiab branch of ngen](https://github.com/CIROH-UA/ngen/tree/ngiab) than contains the model in the /extern/ folder https://github.com/CIROH-UA/ngen/pull/3 https://github.com/CIROH-UA/ngen/pull/3/commits/8e8fdcdd204ff4db96bcc24fd7606014ee780f2c

The extra index url line makes sure pytorch is installed as cpu only because the gpu packages / drivers make the image 6gb larger. 

The package needs to be installed with UV after troute and ngen so that the numpy version matches. 

I've tested this with some example data, the preprocessor will generate the correct configs if you add `--em` to it.
```bash
python -m ngiab_data_cli -i gage-10154200 --start 2010-10-01 --end 2010-11-01 -o lstm_test -sfr --em
```
you can also run the bmi unit tests inside the image by entering the bash shell in the container and 
```bash
cd /ngen/ngen/extern/lstm/
python -m lstm
```

![image](https://github.com/user-attachments/assets/56863da2-68d6-425a-9169-f101c805e093)

