### PR TITLE
Update case_studies_call.md to fix character limit issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/case_studies_call.md
+++ b/.github/ISSUE_TEMPLATE/case_studies_call.md
@@ -1,6 +1,6 @@
 ---
 name: Case Studies Request Form
-about: CIROH consortium members and partners embarking on research projects utilizing the NextGen framework are invited to request access to the research cloud, encompassing services from AWS, Google Cloud using this form. This form must be submitted by Principal Investigator (PI) of the project.
+about: CIROH consortium members and partners are invited to request access to the research cloud (AWS, Google Cloud) using this form. This form must be submitted by PI of the project.
 title: ''
 labels: infrastructure
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/case_studies_call.md
+++ b/.github/ISSUE_TEMPLATE/case_studies_call.md
@@ -1,6 +1,6 @@
 ---
 name: Case Studies Request Form
-about: CIROH consortium members and partners are invited to request access to the research cloud (AWS, Google Cloud) using this form. This form must be submitted by PI of the project.
+about: PI leading CIROH projects may use this form to request cloud computing resources (AWS, Google Cloud, CIROH-2i2c JupyterHub). Access is available to all consortium members and partners.
 title: ''
 labels: infrastructure
 assignees: ''


### PR DESCRIPTION
The issue template wasn't working because the "about" field had too many characters. I shortened it to fix the problem and stay under the 200-character limit