### PR TITLE
viewOnTethys.sh: Docker network error checking

### DIFF
--- a/viewOnTethys.sh
+++ b/viewOnTethys.sh
@@ -170,7 +170,12 @@ _get_filename() {
 
 #create the docker network to communicate between tethys and geoserver
 _create_tethys_docker_network(){
-    _execute_command docker network create -d bridge tethys-network > /dev/null 2>&1
+    network_result=$(_execute_command docker network create -d bridge tethys-network 2>&1)
+    if grep -i "Error" <<< "$network_result"; then
+        echo -e "${BRed}Error while attempting to create Docker network. (Is Docker running?)${Color_Off}"
+        _tear_down
+        exit 1
+    fi
 }
 
 _check_for_existing_tethys_image() {


### PR DESCRIPTION
Adds error checking to the `_create_tethys_docker_network()` function, which currently causes the script to crash silently if it fails.
The grep output from the error check currently prints to the console -- unsure if it should be silenced.
Tested on WSL.
