### PR TITLE
restrict realization.json search to config folder

### DIFF
--- a/docker/HelloNGEN.sh
+++ b/docker/HelloNGEN.sh
@@ -30,7 +30,7 @@ auto_select_file() {
 # Finding files
 HYDRO_FABRIC_CATCHMENTS=$(find . -name "*.gpkg")
 HYDRO_FABRIC_NEXUS=$(find . -name "*.gpkg")
-NGEN_REALIZATIONS=$(find . -name "*realization*.json")
+NGEN_REALIZATIONS=$(find config/ -name "*realization*.json")
 
 # Auto-selecting files if only one is found
 selected_catchment=$(auto_select_file "$HYDRO_FABRIC_CATCHMENTS")


### PR DESCRIPTION
This changes the search for the realization.json file from `/ngen/ngen/data/**/*realization*.json` to `/ngen/ngen/data/config/**/*realization*.json` .

This shouldn't break any of the recent example data or the datastream as both already put the realization in the config folder.

It will fix this issue that stops auto mode working if a folder has been calibrated.
![image](https://github.com/user-attachments/assets/5ace12cb-ac7f-4902-aa12-6d4799e46b7f)
