### PR TITLE
Addition of Datastream Data into the Visualiazer

### DIFF
--- a/viewOnTethys.sh
+++ b/viewOnTethys.sh
@@ -243,15 +243,15 @@ _ensure_visualizer_conf_host_file() {
     local dir
     dir=$(dirname "$file")
 
-    # Make sure parent dir is OK (permissions only on that dir)
-    _ensure_host_dir "$dir"
+    # 1) make sure the directory exists and is writable by the user
+    _ensure_host_dir "$dir" || return 1
 
-    # Create file if missing, then chmod only that file
-    [ -f "$file" ] || touch "$file"
-
+    # 2) create the file if it doesn't exist, and initialise it
     if [ ! -f "$file" ]; then
-        echo '{"model_runs":[]}' > "$json_file"
+        echo '{"model_runs":[]}' > "$file"
     fi
+
+    # 3) ensure *you* can read/write the file
     chmod u+rw "$file"
 }
 

--- a/viewOnTethys.sh
+++ b/viewOnTethys.sh
@@ -150,12 +150,6 @@ check_last_path() {
     else
         DATA_FOLDER_PATH="$1"
     fi
-    # Finding files
-    
-    HYDRO_FABRIC=$(find "$DATA_FOLDER_PATH/config" -iname "*.gpkg")
-    CATCHMENT_FILE=$(find "$DATA_FOLDER_PATH/config" -iname "catchments.geojson")
-    NEXUS_FILE=$(find "$DATA_FOLDER_PATH/config" -iname "nexus.geojson")
-    FLOWPATHTS_FILE=$(find "$DATA_FOLDER_PATH/config" -iname "flowpaths.geojson")
 }
 _get_filename() {
   local full_path="$1"
@@ -217,8 +211,9 @@ _tear_down_tethys(){
 
 _run_tethys(){
     _execute_command docker run --rm -it -d \
-    -v "$MODELS_RUNS_DIRECTORY:$TETHYS_PERSIST_PATH/ngiab_visualizer:ro" \
-    -v "$VISUALIZER_CONF:$TETHYS_PERSIST_PATH/ngiab_visualizer.json:ro" \
+    -v "$MODELS_RUNS_DIRECTORY:$TETHYS_PERSIST_PATH/ngiab_visualizer" \
+    -v "$VISUALIZER_CONF:$TETHYS_PERSIST_PATH/ngiab_visualizer.json" \
+    -v "$DATASTREAM_DIRECTORY:$TETHYS_PERSIST_PATH/.datastream_ngiab" \
     -p 80:80 \
     --platform $PLATFORM \
     --network $DOCKER_NETWORK \
@@ -226,6 +221,7 @@ _run_tethys(){
     --env MEDIA_ROOT="$TETHYS_PERSIST_PATH/media" \
     --env MEDIA_URL="/media/" \
     --env SKIP_DB_SETUP=$SKIP_DB_SETUP \
+    --env DATASTREAM_CONF="$TETHYS_PERSIST_PATH/.datastream_ngiab" \
     $TETHYS_IMAGE_NAME \
     > /dev/null 2>&1
 }
@@ -399,6 +395,7 @@ trap handle_sigint SIGINT
 PLATFORM='linux/amd64'
 VISUALIZER_CONF="$HOME/ngiab_visualizer.json"
 MODELS_RUNS_DIRECTORY="$HOME/ngiab_visualizer"
+DATASTREAM_DIRECTORY="$HOME/.datastream_ngiab"
 TETHYS_CONTAINER_NAME="tethys-ngen-portal"
 DOCKER_NETWORK="tethys-network"
 TETHYS_IMAGE_NAME=awiciroh/tethys-ngiab:main

--- a/viewOnTethys.sh
+++ b/viewOnTethys.sh
@@ -247,7 +247,7 @@ _ensure_visualizer_conf_host_file() {
     _ensure_host_dir "$dir"
 
     # Create file if missing, then chmod only that file
-    # [ -f "$file" ] || touch "$file"
+    [ -f "$file" ] || touch "$file"
 
     if [ ! -f "$file" ]; then
         echo '{"model_runs":[]}' > "$json_file"


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

- Fix permission issues related to docker changing ownership of the volumes on the `viewOnTethys.sh`
- Added new volume mount for the datastream data `viewOnTethys.sh`
- Added a prompt to use any tag for the nigab visualizer

## Removals

- Refactored code

## Updates

- No udpates

## Testing 
### Method
### Screenshots / output snippets


## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)

## Testing checklist

### Target Environment support

- [X] Windows (wsl)
- [X] Linux
- [X] MaxOs (apple silicon)

