### PR TITLE
Update buildx action to v3

### DIFF
--- a/.github/action_templates/build-and-push/action.yaml
+++ b/.github/action_templates/build-and-push/action.yaml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
 
     - name: Set env vars for main branch
       shell: bash


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]
save-state warning during docker/setup-buildx-action

The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Additions

-

## Removals

-

## Updates
update docker/setup-buildx-action to v3
