### PR TITLE
Helper script usability improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # Crash log files
 crash.log
 
+# Data preprocess map log files
+app.log
+
 # Ignore any .tfvars files that are generated automatically for each Terraform run. Most
 # .tfvars files are managed as part of configuration and so should be included in
 # version control.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 ### For general use
 
 - **NGIAB Guide Scripts**: This repository holds several guide scripts: `guide.sh`, `runTeehr.sh`, and `viewOnTethys.sh`. These scripts are the recommended way to run NGIAB.
+  - To see CLI flags for these scripts, execute them with `-h` or see the documentation on [containers and guide scripts](./docs/03_01_CONTAINERS.md).
 
 - **Documentation**: The [`docs/` folder](./docs/00_CONTENTS.md) contains information on all of the finer details that can help you get the most out of the contents of this repository.
   - For broader ecosystem-wide documentation, please visit DocuHub at [docs.ciroh.org/products/ngiab](https://docs.ciroh.org/products/ngiab), where all of the information from this and other NGIAB repositories is mirrored.

--- a/docker/HelloNGEN.sh
+++ b/docker/HelloNGEN.sh
@@ -85,7 +85,7 @@ if [ "$2" == "auto" ]
 fi
 
 echo -e "${YELLOW}Select an option (type a number): ${RESET}"
-options=("Run NextGen model framework in serial mode" "Run NextGen model framework in parallel mode" "Run Bash shell" "Exit")
+options=("Run NextGen model framework in serial mode" "Run NextGen model framework in parallel mode" "Enter Bash shell (for developers)" "Exit")
 select option in "${options[@]}"; do
   case $option in
     "Run NextGen model framework in serial mode"|"Run NextGen model framework in parallel mode")
@@ -109,9 +109,10 @@ select option in "${options[@]}"; do
       echo -e "${YELLOW}Your NGEN run command is $run_command${RESET}"
       break
       ;;
-    "Run Bash shell")
+    "Enter Bash shell (for developers)")
       echo -e "${CYAN}Starting a shell, simply exit to stop the process.${RESET}"
       /bin/bash
+      echo -e "${CYAN}Shell closed. Hit ${YELLOW}ENTER${CYAN} to continue...${RESET}"
       ;;
     "Exit")
       exit 0
@@ -149,12 +150,13 @@ echo -e "${color}${message}${RESET}"
 
 echo -e "${YELLOW}Would you like to continue?${RESET}"
 echo -e "${YELLOW}Select an option (type a number): ${RESET}"
-options=("Interactive-Shell" "Exit")
+options=("Enter Bash shell (for developers)" "Exit")
 select option in "${options[@]}"; do
   case $option in
-    "Interactive-Shell")
+    "Enter Bash shell (for developers)")
       echo -e "${CYAN}Starting a shell, simply exit to stop the process.${RESET}"
       /bin/bash
+      echo -e "${GREEN}Exiting container. Have a nice day.${RESET}"
       break
       ;;
     "Exit")

--- a/docs/03_01_CONTAINERS.md
+++ b/docs/03_01_CONTAINERS.md
@@ -28,6 +28,13 @@ When NGIAB starts up, you will be asked whether you'd like to run in "Serial" or
 
 > The "Run Bash Shell" and "Interactive-Shell" options provide CLI access to the container, allowing its contents to be explored if needed. In practice, this is rarely useful outside of development and debugging.
 
+> **`guide.sh` flags:**  
+> `-d [path]`: Designates the provided path as the data directory to import into the visualizer.  
+> `-h`: Displays usage information, then exits.  
+> `-i [image]`: Specifies which Docker image of NGIAB to run.  
+> `-r`: Retains previous console output when launching the script.  
+> `-t [tag]`: Specifies which Docker image tag of NGIAB to run.  
+
 ### Running the container manually
 For most purposes, the `latest` tag will always be the most appropriate option, offering builds for both AMD64 and ARM64 architectures. However, if you find that Docker is pulling the wrong architecture for your system, then `latest-amd64` and `latest-arm64` are available as aliases.
 
@@ -62,6 +69,14 @@ After `guide.sh` completes an NGIAB run, it will optionally ask to run the TEEHR
 
 Once run, `runTeehr.sh` will prompt for a data path and an image tag. If the script is being run immediately after an NGIAB execution, both the most recent path and recommended tag will most likely be correct. From there, execution will begin automatically.
 
+> **`runTeehr.sh` flags:**  
+> `-d [path]`: Designates the provided path as the data directory to evaluate.  
+> `-h`: Displays usage information, then exits.  
+> `-i [image]`: Specifies which Docker image of the TEEHR container to run.  
+> `-r`: Retains previous console output when launching the script.  
+> `-t [tag]`: Specifies which Docker image tag of the TEEHR container to run.  
+> `-y`: Launches the evaluation workflow immediately, skipping the initial confirmation prompt.  
+
 ### Running the container manually
 The TEEHR integration offers both `latest` and `x86` tags, which support ARM64 and AMD64 systems, respectively. Be sure to choose the appropriate tag for your system's architecture.
 
@@ -93,6 +108,15 @@ Once run, `viewOnTethys.sh` will prompt for a data path and an image tag. If the
 
 For more information on using the visualizer, please see the [ngiab-client](https://github.com/CIROH-UA/ngiab-client) repository.
 <!-- TODO: Update link target once visualizer docs are ready -->
+
+> **`viewOnTethys.sh` flags:**  
+> `-d [path]`: Designates the provided path as the data directory to import into the visualizer.  
+> `-h`: Displays usage information, then exits.  
+> `-i [image]`: Specifies which Docker image of the visualizer to run.  
+> `-n`: Launches the visualizer immediately without importing a data directory.  
+> `-r`: Retains previous console output when launching the script.  
+> `-t [tag]`: Specifies which Docker image tag of the visualizer to run.  
+> `-y`: Immediately requests to import a data directory.  
 
 ### Running the container manually
 Due to the complexity of launching the Data Visualizer, launching it without using a guide script is not currently recommended. If necessary, please reference `viewOnTethys.sh` for more details on this process. 

--- a/docs/03_04_MODELS.md
+++ b/docs/03_04_MODELS.md
@@ -53,7 +53,7 @@ Library file path: `/dmod/shared_libs/libtopmodelbmi.so.1.0.0`
 > *Fork developed by [Jonathan Frame](https://github.com/jmframe)*
 
 LSTM networks are a type of recurrent neural network used in deep learning.
-This LSTM module is specifically tailored for generalize streamflow prediction within CONUS.
+This LSTM module is specifically tailored for generalized streamflow prediction within CONUS.
 
 Python class: `lstm.bmi_LSTM` <!-- TODO: verify -->
 

--- a/guide.sh
+++ b/guide.sh
@@ -195,7 +195,7 @@ while getopts 'd:hrt:' flag; do
 done
 
 # For consistency with other scripts: if no flags provided, first argument should be used as data path
-if [ $FLAGS_USED == false ] && [ -n $1 ]; then
+if [ "$FLAGS_USED" == false ] && [ -n "$1" ]; then
     DATA_FOLDER_PATH="$1"
 fi
 
@@ -217,7 +217,7 @@ echo -e "\n  ${ARROW} \033[38;5;205moutputs/\033[0m - Target directory for simul
 echo -e "          \033[38;5;117m└─ Flow estimates, water levels, and diagnostic information\033[0m"
 
 # If no path provided as an argument...
-if [ -z $HOST_DATA_PATH ]; then
+if [ -z "$HOST_DATA_PATH" ]; then
     echo -e "\n${INFO_MARK} ${BWhite}Please specify a directory containing these components below.${Color_Off}\n"
 
     # Path selection with improved user experience and fixed formatting
@@ -426,7 +426,7 @@ fi
 print_section_header "MODEL EXECUTION OPTIONS"
 
 IMAGE_NAME="$NGEN_IMAGE_NAME:$NGEN_IMAGE_TAG"
-$USING_CUSTOM_TAG && echo -e "  ${CHECK_MARK} Using specified tag: ${BGreen}$IMAGE_NAME${Color_Off}\n"
+$CUSTOM_TAG_USED && echo -e "  ${CHECK_MARK} Using specified tag: ${BGreen}$IMAGE_NAME${Color_Off}\n"
 
 echo -e "${ARROW} ${BWhite}Please select an option to proceed:${Color_Off}\n"
 options=("Run NextGen using existing local docker image" "Update to latest docker image and run" "Exit")
@@ -507,7 +507,7 @@ if [ $Final_Outputs_Count -gt 0 ]; then
             fi
             
             # Disable clearing console if needed
-            if [ $CLEAR_CONSOLE == true ]; then
+            if [ "$CLEAR_CONSOLE" == true ]; then
                 teehr_call="$TEEHR_SCRIPT -y -d $HOST_DATA_PATH"
             else
                 teehr_call="$TEEHR_SCRIPT -y -r -d $HOST_DATA_PATH"
@@ -577,7 +577,7 @@ if [ $Final_Outputs_Count -gt 0 ]; then
             fi
 
             # Disable clearing console if needed
-            if [ $CLEAR_CONSOLE == true ]; then
+            if [ "$CLEAR_CONSOLE" == true ]; then
                 tethys_call="$TETHYS_SCRIPT -d $HOST_DATA_PATH"
             else
                 tethys_call="$TETHYS_SCRIPT -r -d $HOST_DATA_PATH"

--- a/guide.sh
+++ b/guide.sh
@@ -68,7 +68,6 @@ DO_STARTUP_PROMPT=true # If false, skips the "Would you like to run a TEEHR eval
 FLAGS_USED=false # Backwards compatibility. If false, uses the first argument as the data directory path.
 CUSTOM_TAG_USED=false # Used to provide direct feedback if a custom tag is used.
 
-
 # Function for animated loading with gradient colors
 show_loading() {
     local message=$1

--- a/guide.sh
+++ b/guide.sh
@@ -172,17 +172,19 @@ print_usage() {
     echo -e "${BYellow}Options:${Color_Off}"
     echo -e "${BCyan}  -d [path]:${Color_Off} Designates the provided path as the data directory to import into the visualizer."
     echo -e "${BCyan}  -h:${Color_Off} Displays usage information, then exits."
+    echo -e "${BCyan}  -i [image]:${Color_Off} Specifies which Docker image of NGIAB to run."
     echo -e "${BCyan}  -r:${Color_Off} Retains previous console output when launching the script."
     echo -e "${BCyan}  -t [tag]:${Color_Off} Specifies which Docker image tag of NGIAB to run."
 }
 
 
 # Pre-script execution
-while getopts 'd:hrt:' flag; do
+while getopts 'd:hi:rt:' flag; do
     case "${flag}" in
         d) HOST_DATA_PATH="${OPTARG}" ;;
         h) print_usage
            exit 1 ;;
+        i) NGEN_IMAGE_NAME="${OPTARG}" ;;
         r) CLEAR_CONSOLE=false ;;
         t) NGEN_IMAGE_TAG="${OPTARG}"
            CUSTOM_TAG_USED=true ;;

--- a/guide.sh
+++ b/guide.sh
@@ -54,11 +54,20 @@ TETHYS_SCRIPT="./viewOnTethys.sh"
 TEEHR_SCRIPT="./runTeehr.sh"
 
 # Container and image constants
+NGEN_IMAGE_NAME="awiciroh/ciroh-ngen-image"
+NGEN_IMAGE_TAG="latest"
+# (The rest of these are solely used to manage shutdowns)
 DOCKER_NETWORK="tethys-network"
 TETHYS_CONTAINER_NAME="tethys-ngen-portal"
 TETHYS_IMAGE_NAME="awiciroh/tethys-ngiab"
 TEEHR_IMAGE_NAME="awiciroh/ngiab-teehr"
-NGEN_IMAGE_NAME="awiciroh/ciroh-ngen-image"
+
+# Parameters
+DATA_FOLDER_PATH="" # Path to the model run being evaluated.
+DO_STARTUP_PROMPT=true # If false, skips the "Would you like to run a TEEHR evaluation?" prompt.
+FLAGS_USED=false # Backwards compatibility. If false, uses the first argument as the data directory path.
+CUSTOM_TAG_USED=false # Used to provide direct feedback if a custom tag is used.
+
 
 # Function for animated loading with gradient colors
 show_loading() {
@@ -82,17 +91,17 @@ show_loading() {
 print_section_header() {
     local title=$1
     local width=70
-    local padding=$(( (width - ${#title}) / 2 ))
+    local right_padding=$(( (width - ${#title}) / 2 ))
+    local left_padding=$(( (width - ${#title}) % 2 + right_padding ))
     
     # Create a more visually appealing section header with light blue background
     echo -e "\n\033[48;5;117m$(printf "%${width}s" " ")\033[0m"
-    echo -e "\033[48;5;117m$(printf "%${padding}s" " ")${BBlack}${title}$(printf "%${padding}s" " ")\033[0m"
+    echo -e "\033[48;5;117m$(printf "%${left_padding}s" " ")${BBlack}${title}$(printf "%${right_padding}s" " ")\033[0m"
     echo -e "\033[48;5;117m$(printf "%${width}s" " ")\033[0m\n"
 }
 
 # Welcome banner with improved design
 print_welcome_banner() {
-    clear
     echo -e "\n\n"
     echo -e "\033[38;5;39m  ╔══════════════════════════════════════════════════════════════════════════════════════════╗\033[0m"
     echo -e "\033[38;5;39m  ║                                                                                          ║\033[0m"
@@ -158,6 +167,42 @@ handle_sigint() {
 trap handle_sigint SIGINT
 trap clean_up_resources EXIT
 
+
+print_usage() {
+    echo -e "${BYellow}Usage: ${BCyan}guide.sh [arg ...]${Color_Off}"
+    echo -e "${BYellow}Options:${Color_Off}"
+    echo -e "${BCyan}  -d [path]:${Color_Off} Designates the provided path as the data directory to import into the visualizer."
+    echo -e "${BCyan}  -h:${Color_Off} Displays usage information, then exits."
+    echo -e "${BCyan}  -r:${Color_Off} Retains previous console output when launching the script."
+    echo -e "${BCyan}  -t [tag]:${Color_Off} Specifies which Docker image tag of NGIAB to run."
+}
+
+
+# Pre-script execution
+while getopts 'd:hrt:' flag; do
+    case "${flag}" in
+        d) HOST_DATA_PATH="${OPTARG}" ;;
+        h) print_usage
+           exit 1 ;;
+        r) CLEAR_CONSOLE=false ;;
+        t) NGEN_IMAGE_TAG="${OPTARG}"
+           CUSTOM_TAG_USED=true ;;
+        *) echo -e "${CROSS_MARK} ${BRed}ERROR: Unrecognized flag.${Color_Off}"
+           print_usage
+           exit 1 ;;
+    esac
+    FLAGS_USED=true
+done
+
+# For consistency with other scripts: if no flags provided, first argument should be used as data path
+if [ $FLAGS_USED == false ] && [ -n $1 ]; then
+    DATA_FOLDER_PATH="$1"
+fi
+
+
+## Main execution
+
+$CLEAR_CONSOLE && clear
 print_welcome_banner
 
 # Input data section with improved descriptions
@@ -171,25 +216,28 @@ echo -e "          \033[38;5;117m└─ Model parameters, simulation period, and
 echo -e "\n  ${ARROW} \033[38;5;205moutputs/\033[0m - Target directory for simulation results"
 echo -e "          \033[38;5;117m└─ Flow estimates, water levels, and diagnostic information\033[0m"
 
-echo -e "\n${INFO_MARK} ${BWhite}Please specify a directory containing these components below.${Color_Off}\n"
+# If no path provided as an argument...
+if [ -z $HOST_DATA_PATH ]; then
+    echo -e "\n${INFO_MARK} ${BWhite}Please specify a directory containing these components below.${Color_Off}\n"
 
-# Path selection with improved user experience and fixed formatting
-if [ -f "$CONFIG_FILE" ]; then
-    LAST_PATH=$(cat "$CONFIG_FILE")
-    echo -e "${INFO_MARK} Last used data directory: ${BBlue}$LAST_PATH${Color_Off}"
-    echo -ne "  ${ARROW} Use the same path? [Y/n]: "
-    read -e use_last_path
-    if [[ "$use_last_path" != [Nn]* ]]; then
-        HOST_DATA_PATH=$LAST_PATH
-        echo -e "  ${CHECK_MARK} Using previously configured path"
+    # Path selection with improved user experience and fixed formatting
+    if [ -f "$CONFIG_FILE" ]; then
+        LAST_PATH=$(cat "$CONFIG_FILE")
+        echo -e "${INFO_MARK} Last used data directory: ${BBlue}$LAST_PATH${Color_Off}"
+        echo -ne "  ${ARROW} Use the same path? [Y/n]: "
+        read -e use_last_path
+        if [[ "$use_last_path" != [Nn]* ]]; then
+            HOST_DATA_PATH=$LAST_PATH
+            echo -e "  ${CHECK_MARK} Using previously configured path"
+        else
+            echo -ne "  ${ARROW} Enter your input data directory path: "
+            read -e HOST_DATA_PATH
+        fi
     else
+        echo -e "${INFO_MARK} ${BYellow}No previous configuration found${Color_Off}"
         echo -ne "  ${ARROW} Enter your input data directory path: "
         read -e HOST_DATA_PATH
     fi
-else
-    echo -e "${INFO_MARK} ${BYellow}No previous configuration found${Color_Off}"
-    echo -ne "  ${ARROW} Enter your input data directory path: "
-    read -e HOST_DATA_PATH
 fi
 
 # Handle paths with special characters properly
@@ -374,10 +422,11 @@ else
     handle_error "Docker not found. This script requires Docker to run the NextGen model."
 fi
 
-IMAGE_NAME=$NGEN_IMAGE_NAME:latest
-
 # Model run options with improved visuals
 print_section_header "MODEL EXECUTION OPTIONS"
+
+IMAGE_NAME="$NGEN_IMAGE_NAME:$NGEN_IMAGE_TAG"
+$USING_CUSTOM_TAG && echo -e "  ${CHECK_MARK} Using specified tag: ${BGreen}$IMAGE_NAME${Color_Off}\n"
 
 echo -e "${ARROW} ${BWhite}Please select an option to proceed:${Color_Off}\n"
 options=("Run NextGen using existing local docker image" "Update to latest docker image and run" "Exit")
@@ -457,8 +506,15 @@ if [ $Final_Outputs_Count -gt 0 ]; then
                 chmod +x "$TEEHR_SCRIPT"
             fi
             
+            # Disable clearing console if needed
+            if [ $CLEAR_CONSOLE == true ]; then
+                teehr_call="$TEEHR_SCRIPT -y -d $HOST_DATA_PATH"
+            else
+                teehr_call="$TEEHR_SCRIPT -y -r -d $HOST_DATA_PATH"
+            fi
+
             # Call the runTeehr.sh script with the data path
-            if ! "$TEEHR_SCRIPT" "$HOST_DATA_PATH"; then
+            if ! bash -c "$teehr_call"; then
                 echo -e "\n${WARNING_MARK} ${BRed}Failed to run TEEHR evaluation.${Color_Off}"
                 echo -e "  ${INFO_MARK} Check that the runTeehr.sh script is properly configured."
             fi
@@ -519,9 +575,16 @@ if [ $Final_Outputs_Count -gt 0 ]; then
             if [ ! -x "$TETHYS_SCRIPT" ]; then
                 chmod +x "$TETHYS_SCRIPT"
             fi
-            
+
+            # Disable clearing console if needed
+            if [ $CLEAR_CONSOLE == true ]; then
+                tethys_call="$TETHYS_SCRIPT -d $HOST_DATA_PATH"
+            else
+                tethys_call="$TETHYS_SCRIPT -r -d $HOST_DATA_PATH"
+            fi
+
             # Call the viewOnTethys.sh script with the data path
-            if ! "$TETHYS_SCRIPT" "$HOST_DATA_PATH"; then
+            if ! bash -c "$tethys_call"; then
                 echo -e "\n${WARNING_MARK} ${BRed}Failed to launch Tethys visualization.${Color_Off}"
                 echo -e "  ${INFO_MARK} Check that the viewOnTethys.sh script is properly configured."
             fi
@@ -542,7 +605,7 @@ print_section_header "SESSION COMPLETE"
 
 # Create a fancy box for the thank you message
 echo -e "\033[38;5;39m  ┌────────────────────────────────────────────────────────────┐\033[0m"
-echo -e "\033[38;5;39m  │\033[48;5;39m\033[1;37m  Thank you for using NGIAB!                                  \033[0m\033[38;5;39m  │\033[0m"
+echo -e "\033[38;5;39m  │\033[48;5;39m\033[1;37m  Thank you for using NGIAB!                               \033[0m\033[38;5;39m  │\033[0m"
 echo -e "\033[38;5;39m  └────────────────────────────────────────────────────────────┘\033[0m\n"
 
 echo -e "${INFO_MARK} ${BWhite}Your simulation results are available at:${Color_Off}"

--- a/runTeehr.sh
+++ b/runTeehr.sh
@@ -243,7 +243,7 @@ while getopts 'd:hrt:y' flag; do
 done
 
 # Backwards compatibility: If no flags provided, first argument should be used as data path
-if [ $FLAGS_USED == false ] && [ -n $1 ]; then
+if [ "$FLAGS_USED" == false ] && [ -n "$1" ]; then
     DATA_FOLDER_PATH="$1"
 fi
 
@@ -258,7 +258,7 @@ print_section_header "TEEHR EVALUATION SETUP"
 echo -e "${INFO_MARK} ${BWhite}TEEHR will evaluate model outputs against observations${Color_Off}"
 echo -e "  ${ARROW} Learn more: ${UBlue}https://rtiinternational.github.io/ngiab-teehr/${Color_Off}\n"
 
-if [ $DO_STARTUP_PROMPT == true ]; then
+if [ "$DO_STARTUP_PROMPT" == true ]; then
     echo -e "${ARROW} ${BWhite}Would you like to run a TEEHR evaluation on your model outputs?${Color_Off}"
     read -erp "  Run evaluation? [Y/n]: " run_teehr_choice
 else

--- a/runTeehr.sh
+++ b/runTeehr.sh
@@ -51,9 +51,15 @@ set -e
 
 # Constants
 CONFIG_FILE="$HOME/.host_data_path.conf"
-DATA_FOLDER_PATH=""
 IMAGE_NAME="awiciroh/ngiab-teehr"
 TEEHR_CONTAINER_PREFIX="teehr-evaluation"
+
+# Parameters
+DATA_FOLDER_PATH="" # Path to the model run being evaluated.
+FORCED_IMAGE_TAG="" # If non-empty, overrides the normal tag selection process.
+DO_STARTUP_PROMPT=true # If false, skips the "Would you like to run a TEEHR evaluation?" prompt.
+CLEAR_CONSOLE=true # If true, clears the console when starting execution.
+FLAGS_USED=false # Backwards compatibility. If false, uses the first argument as the data directory path.
 
 # Function for animated loading with gradient colors
 show_loading() {
@@ -77,17 +83,17 @@ show_loading() {
 print_section_header() {
     local title=$1
     local width=70
-    local padding=$(( (width - ${#title}) / 2 ))
+    local right_padding=$(( (width - ${#title}) / 2 ))
+    local left_padding=$(( (width - ${#title}) % 2 + right_padding ))
     
     # Create a more visually appealing section header with light blue background
     echo -e "\n\033[48;5;117m$(printf "%${width}s" " ")\033[0m"
-    echo -e "\033[48;5;117m$(printf "%${padding}s" " ")${BBlack}${title}$(printf "%${padding}s" " ")\033[0m"
+    echo -e "\033[48;5;117m$(printf "%${left_padding}s" " ")${BBlack}${title}$(printf "%${right_padding}s" " ")\033[0m"
     echo -e "\033[48;5;117m$(printf "%${width}s" " ")\033[0m\n"
 }
 
 # Welcome banner with improved design - fixed formatting
 print_welcome_banner() {
-    clear
     echo -e "\n\n"
     echo -e "\033[38;5;39m  ╔══════════════════════════════════════════════════════════════════════════════════════════╗\033[0m"
     echo -e "\033[38;5;39m  ║                                                                                          ║\033[0m"
@@ -200,52 +206,96 @@ check_and_read_config() {
 }
 
 # Handle path from arguments or config
-check_last_path() {
-    if [[ -z "$1" ]]; then
+handle_data_path() {
+    if [[ -z "$DATA_FOLDER_PATH" ]]; then
         check_and_read_config
     else
-        DATA_FOLDER_PATH="$1"
         check_if_data_folder_exists
     fi
 }
 
-# Main script execution
-print_welcome_banner
 
-# Check if data path is provided as argument
-check_last_path "$1"
+print_usage() {
+    echo -e "${BYellow}Usage: ${BCyan}runTeehr.sh [arg ...]${Color_Off}"
+    echo -e "${BYellow}Options:${Color_Off}"
+    echo -e "${BCyan}  -d [path]:${Color_Off} Designates the provided path as the data directory to evaluate."
+    echo -e "${BCyan}  -h:${Color_Off} Displays usage information, then exits."
+    echo -e "${BCyan}  -r:${Color_Off} Retains previous console output when launching the script."
+    echo -e "${BCyan}  -t [tag]:${Color_Off} Specifies which Docker image tag of the TEEHR container to run."
+    echo -e "${BCyan}  -y:${Color_Off} Launches the evaluation workflow immediately, skipping the initial confirmation prompt."
+}
+
+
+# Pre-script execution
+while getopts 'd:hrt:y' flag; do
+    case "${flag}" in
+        d) DATA_FOLDER_PATH="${OPTARG}";;
+        h) print_usage
+           exit 1 ;;
+        r) CLEAR_CONSOLE=false ;;
+        t) FORCED_IMAGE_TAG="${OPTARG}" ;;
+        y) DO_STARTUP_PROMPT=false ;;
+        *) echo -e "${CROSS_MARK} ${BRed}ERROR: Unrecognized flag.${Color_Off}"
+           print_usage
+           exit 1 ;;
+    esac
+    FLAGS_USED=true
+done
+
+# Backwards compatibility: If no flags provided, first argument should be used as data path
+if [ $FLAGS_USED == false ] && [ -n $1 ]; then
+    DATA_FOLDER_PATH="$1"
+fi
+
+
+# Main script execution
+
+$CLEAR_CONSOLE && clear
+print_welcome_banner
 
 print_section_header "TEEHR EVALUATION SETUP"
 
 echo -e "${INFO_MARK} ${BWhite}TEEHR will evaluate model outputs against observations${Color_Off}"
 echo -e "  ${ARROW} Learn more: ${UBlue}https://rtiinternational.github.io/ngiab-teehr/${Color_Off}\n"
 
-echo -e "${ARROW} ${BWhite}Would you like to run a TEEHR evaluation on your model outputs?${Color_Off}"
-read -erp "  Run evaluation? [Y/n]: " run_teehr_choice
+if [ $DO_STARTUP_PROMPT == true ]; then
+    echo -e "${ARROW} ${BWhite}Would you like to run a TEEHR evaluation on your model outputs?${Color_Off}"
+    read -erp "  Run evaluation? [Y/n]: " run_teehr_choice
+else
+    run_teehr_choice="y"
+fi
 
 # Default to 'y' if input is empty
 if [[ -z "$run_teehr_choice" ]]; then
     run_teehr_choice="y"
 fi
 
+# Check data directory validity as appropriate
+handle_data_path
+
 # Execute the TEEHR evaluation if requested
 if [[ "$run_teehr_choice" =~ ^[Yy] ]]; then
+
+    if [[ -z "$FORCED_IMAGE_TAG" ]]; then
     # Detect platform architecture for default tag
-    if uname -a | grep -q 'arm64\|aarch64'; then
-        default_tag="latest" # ARM64 architecture
+        if uname -a | grep -q 'arm64\|aarch64'; then
+            default_tag="latest" # ARM64 architecture
+        else
+            default_tag="x86"    # x86 architecture
+        fi
+        
+        echo -e "\n${ARROW} ${BWhite}System architecture detected: ${BCyan}$(uname -m)${Color_Off}"
+        echo -e "  ${INFO_MARK} Recommended image tag: ${BCyan}$default_tag${Color_Off}"
+        read -erp "$(echo -ne "  ${ARROW} Specify TEEHR image tag [default: $default_tag]: ")" teehr_image_tag
+
+        if [[ -z "$teehr_image_tag" ]]; then
+            teehr_image_tag="$default_tag"
+            echo -e "  ${CHECK_MARK} ${BGreen}Using default tag: $default_tag${Color_Off}"
+        else
+            echo -e "  ${CHECK_MARK} ${BGreen}Using specified tag: $teehr_image_tag${Color_Off}"
+        fi
     else
-        default_tag="x86"    # x86 architecture
-    fi
-    
-    echo -e "\n${ARROW} ${BWhite}System architecture detected: ${BCyan}$(uname -m)${Color_Off}"
-    echo -e "  ${INFO_MARK} Recommended image tag: ${BCyan}$default_tag${Color_Off}"
-    echo -ne "  ${ARROW} Specify TEEHR image tag [default: $default_tag]: "
-    read -e teehr_image_tag
-    
-    if [[ -z "$teehr_image_tag" ]]; then
-        teehr_image_tag="$default_tag"
-        echo -e "  ${CHECK_MARK} ${BGreen}Using default tag: $default_tag${Color_Off}"
-    else
+        teehr_image_tag="$FORCED_IMAGE_TAG"
         echo -e "  ${CHECK_MARK} ${BGreen}Using specified tag: $teehr_image_tag${Color_Off}"
     fi
 
@@ -306,7 +356,7 @@ if [[ "$run_teehr_choice" =~ ^[Yy] ]]; then
     echo -e "\n${INFO_MARK} You can visualize these results using the Tethys platform"
     echo -e "  ${ARROW} Run ${UBlue}./viewOnTethys.sh $DATA_FOLDER_PATH${Color_Off} to start visualization"
 else
-    echo -e "\n${INFO_MARK} ${BCyan}Skipping TEEHR evaluation.${Color_Off}"
+    echo -e "\n${INFO_MARK} ${BCyan}Cancelling TEEHR evaluation.${Color_Off}"
 fi
 
 echo -e "\n${BG_Blue}${BWhite} Thank you for using NGIAB! ${Color_Off}"

--- a/runTeehr.sh
+++ b/runTeehr.sh
@@ -220,6 +220,7 @@ print_usage() {
     echo -e "${BYellow}Options:${Color_Off}"
     echo -e "${BCyan}  -d [path]:${Color_Off} Designates the provided path as the data directory to evaluate."
     echo -e "${BCyan}  -h:${Color_Off} Displays usage information, then exits."
+    echo -e "${BCyan}  -i [image]:${Color_Off} Specifies which Docker image of the TEEHR container to run."
     echo -e "${BCyan}  -r:${Color_Off} Retains previous console output when launching the script."
     echo -e "${BCyan}  -t [tag]:${Color_Off} Specifies which Docker image tag of the TEEHR container to run."
     echo -e "${BCyan}  -y:${Color_Off} Launches the evaluation workflow immediately, skipping the initial confirmation prompt."
@@ -229,10 +230,11 @@ print_usage() {
 # Pre-script execution
 while getopts 'd:hrt:y' flag; do
     case "${flag}" in
-        d) DATA_FOLDER_PATH="${OPTARG}";;
+        d) DATA_FOLDER_PATH="${OPTARG}" ;;
         h) print_usage
            exit 1 ;;
         r) CLEAR_CONSOLE=false ;;
+        i) IMAGE_NAME="${OPTARG}" ;;
         t) FORCED_IMAGE_TAG="${OPTARG}" ;;
         y) DO_STARTUP_PROMPT=false ;;
         *) echo -e "${CROSS_MARK} ${BRed}ERROR: Unrecognized flag.${Color_Off}"

--- a/viewOnTethys.sh
+++ b/viewOnTethys.sh
@@ -54,12 +54,19 @@ CONFIG_FILE="$HOME/.host_data_path.conf"
 DOCKER_NETWORK="tethys-network"
 TETHYS_CONTAINER_NAME="tethys-ngen-portal"
 TETHYS_REPO="awiciroh/tethys-ngiab"
-TETHYS_TAG="latest"
+
 MODELS_RUNS_DIRECTORY="$HOME/ngiab_visualizer"
 DATASTREAM_DIRECTORY="$HOME/.datastream_ngiab"
 VISUALIZER_CONF="$MODELS_RUNS_DIRECTORY/ngiab_visualizer.json"
 TETHYS_PERSIST_PATH="/var/lib/tethys_persist"
 SKIP_DB_SETUP=false
+
+# Parameters
+DATA_FOLDER_PATH="" # If non-empty, gets used as the gage path to import.
+TETHYS_TAG="" # If non-empty, gets used as the image tag.
+IMPORT_GAGE="ask" # "ask"/"yes"/"no"/"done"
+CLEAR_CONSOLE=true # If true, clears the console when starting execution.
+FLAGS_USED=false # Backwards compatibility. If false, uses the first argument as the data directory path.
 
 # Disable error trapping initially so we can catch and report errors
 set +e
@@ -86,23 +93,27 @@ show_loading() {
 print_section_header() {
     local title=$1
     local width=70
-    local padding=$(( (width - ${#title}) / 2 ))
+    local right_padding=$(( (width - ${#title}) / 2 ))
+    local left_padding=$(( (width - ${#title}) % 2 + right_padding ))
     
     # Create a more visually appealing section header with light blue background
     echo -e "\n\033[48;5;117m$(printf "%${width}s" " ")\033[0m"
-    echo -e "\033[48;5;117m$(printf "%${padding}s" " ")${BBlack}${title}$(printf "%${padding}s" " ")\033[0m"
+    echo -e "\033[48;5;117m$(printf "%${left_padding}s" " ")${BBlack}${title}$(printf "%${right_padding}s" " ")\033[0m"
     echo -e "\033[48;5;117m$(printf "%${width}s" " ")\033[0m\n"
 }
 
-# Simple banner without complex formatting
+# Welcome banner with improved design - fixed formatting
 print_welcome_banner() {
-    clear
+    echo -e "\n\n"
+    echo -e "\033[38;5;39m  ╔═══════════════════════════════════════════════════════════════════════════════════╗\033[0m"
+    echo -e "\033[38;5;39m  ║                                                                                   ║\033[0m"
+    echo -e "\033[38;5;39m  ║  \033[1;38;5;231mCIROH: NextGen In A Box (NGIAB) - Tethys\033[38;5;39m                                         ║\033[0m"
+    echo -e "\033[38;5;39m  ║  \033[1;38;5;231mInteractive Model Output Visualization\033[38;5;39m                                           ║\033[0m"
+    echo -e "\033[38;5;39m  ║                                                                                   ║\033[0m"
+    echo -e "\033[38;5;39m  ╚═══════════════════════════════════════════════════════════════════════════════════╝\033[0m"
     echo -e "\n"
-    echo -e "${BBlue}=================================================${Color_Off}"
-    echo -e "${BBlue}|  CIROH: NextGen In A Box (NGIAB) - Tethys     |${Color_Off}"
-    echo -e "${BBlue}|  Interactive Model Output Visualization       |${Color_Off}"
-    echo -e "${BBlue}=================================================${Color_Off}"
-    echo -e "\n${INFO_MARK} ${BWhite}Developed by CIROH${Color_Off}\n"
+    echo -e "  ${INFO_MARK} \033[1;38;5;231mDeveloped by CIROH\033[0m"
+    echo -e "\n"
     sleep 1
 }
 
@@ -222,10 +233,12 @@ create_tethys_docker_network() {
 }
 
 set_tethys_tag() {
-    echo -e "${Color_Off}${BBlue}Specify the Tethys image tag to use: ${Color_Off}"
-    read -erp "$(echo -e "  ${ARROW} Tag (e.g. v0.2.1, default: latest): ")" TETHYS_TAG
     if [[ -z "$TETHYS_TAG" ]]; then
-        TETHYS_TAG="latest"
+        echo -e "${Color_Off}${BBlue}Specify the Tethys image tag to use: ${Color_Off}"
+        read -erp "$(echo -e "  ${ARROW} Tag (e.g. v0.2.1, default: latest): ")" TETHYS_TAG
+        if [[ -z "$TETHYS_TAG" ]]; then
+            TETHYS_TAG="latest"
+        fi
     fi
 }
 
@@ -443,10 +456,7 @@ tear_down() {
     return 0
 }
 
-copy_models_run() {
-    local input_path="$1"
-    local models_dir="$MODELS_RUNS_DIRECTORY"
-
+prompt_fresh_start() {
     # ────────────────────────────────────────────────────────────────────
     # 0. Top-level directory already contains runs?  Ask user what to do.
     # ────────────────────────────────────────────────────────────────────
@@ -466,6 +476,11 @@ copy_models_run() {
             esac
         done
     fi
+}
+
+copy_models_run() {
+    local input_path="$1"
+    local models_dir="$MODELS_RUNS_DIRECTORY"
 
     # ────────────────────────────────────────────────────────────────────
     # 1. Ensure ~/ngiab_visualizer exists & is writable
@@ -482,6 +497,7 @@ copy_models_run() {
     local final_copied_path="$model_run_path"
 
     # 3. Copy / overwrite / duplicate – user-driven
+    overwrite_used=false # Message-passing for add_model_run()
     if [ ! -e "$model_run_path" ]; then
         cp -r "$input_path" "$models_dir/" || {
             echo -e "  ${CROSS_MARK} ${BRed}Copy failed${Color_Off}" >&2 ; return 1 ; }
@@ -497,6 +513,7 @@ copy_models_run() {
                     cp -r "$input_path" "$models_dir/" || {
                         echo -e "  ${CROSS_MARK} ${BRed}Overwrite failed${Color_Off}" >&2 ; return 1 ; }
                     echo -e "  ${CHECK_MARK} ${BCyan}Overwritten${Color_Off} ➜ $model_run_path" >&2
+                    overwrite_used=true
                     break ;;
                 [Dd]* )
                     echo -ne "  ${ARROW} ${BBlue}New directory name:${Color_Off} " >&2
@@ -552,7 +569,30 @@ add_model_run() {
         return 1
     fi
 
-    # ── 3. Append the new record ────────────────────────────────────────
+    # ── 3. If overwriting, discard the previous record ──────────────────
+    if [ ! $overwrite_used ] ; then
+        : # Nothing to do here
+    elif $jq_exec \
+        --arg base_name    "$base_name" \
+        --arg final_path   "$final_path" \
+        --arg current_time "$current_time" \
+        --arg uuid         "$new_uuid" \
+        '
+        del (
+            .model_runs[]
+          | select(.label == $base_name and .path == $final_path)
+        )
+        ' < "$json_file" > "${json_file}.tmp" && \
+       mv -f "${json_file}.tmp" "$json_file"; then
+        ## ► success message
+        echo -e "  ${CHECK_MARK} ${BCyan}Deregistered overwritten model runs from $json_file.${Color_Off}"
+    else
+        ## ► failure message
+        echo -e "  ${WARNING_MARK} ${BYellow}Failed to unregister overwritten model run from $json_file.${Color_Off}"
+        echo -e "    ${INFO_MARK} ${BCyan}This may result in duplicate model run listings, but is otherwise harmless.${Color_Off}"
+    fi
+
+    # ── 4. Append the new record ────────────────────────────────────────
     if $jq_exec \
         --arg base_name    "$base_name" \
         --arg final_path   "$final_path" \
@@ -628,13 +668,67 @@ pause_script_execution() {
     done
 }
 
+
+print_usage() {
+    echo -e "${BYellow}Usage: ${BCyan}runTeehr.sh [arg ...]${Color_Off}"
+    echo -e "${BYellow}Options:${Color_Off}"
+    echo -e "${BCyan}  -d [path]:${Color_Off} Designates the provided path as the data directory to import into the visualizer."
+    echo -e "${BCyan}  -h:${Color_Off} Displays usage information, then exits."
+    echo -e "${BCyan}  -i:${Color_Off} Immediately requests to import a data directory."
+    echo -e "${BCyan}  -n:${Color_Off} Launches the visualizer immediately without importing a data directory."
+    echo -e "${BCyan}  -r:${Color_Off} Retains previous console output when launching the script."
+    echo -e "${BCyan}  -t [tag]:${Color_Off} Specifies which Docker image tag of the visualizer to run."
+}
+
+
+# Pre-script execution
+while getopts 'd:hinrt:' flag; do
+    case "${flag}" in
+        d) DATA_FOLDER_PATH="${OPTARG}";;
+        h) print_usage
+           exit 1 ;;
+        i) IMPORT_GAGE="yes" ;;
+        n) IMPORT_GAGE="no";;
+        r) CLEAR_CONSOLE=false ;;
+        t) TETHYS_TAG="${OPTARG}" ;;
+        *) echo -e "${CROSS_MARK} ${BRed}ERROR: Unrecognized flag.${Color_Off}"
+           print_usage
+           exit 1 ;;
+    esac
+    FLAGS_USED=true
+done
+
+if [ -n "$DATA_FOLDER_PATH" ] && [ $IMPORT_GAGE == "no" ]; then
+    echo -e "${CROSS_MARK} ${BRed}ERROR: Flags -g and -l are incompatible.${Color_Off}"
+    print_usage
+    exit 1
+fi
+
+# Backwards compatibility: If no flags provided, first argument should be used as data path
+if [ $FLAGS_USED == false ] && [ -n $1 ]; then
+    DATA_FOLDER_PATH="$1"
+fi
+
+
 # Main script execution
+$CLEAR_CONSOLE && clear
 print_welcome_banner
 
-# Check if data path is provided as argument
-DATA_FOLDER_PATH="$1"
+# Check if a data path should be added
+while [[ -z "$DATA_FOLDER_PATH" && $IMPORT_GAGE == "ask" ]]; do
+    read -erp "$(echo -e "  ${ARROW} Import a NextGen model run? [Y/n]: ")" import_choice
+    if [[ "$import_choice" =~ ^[Yy] ]]; then
+        IMPORT_GAGE="yes"
+    elif [[ "$import_choice" =~ ^[Nn] ]]; then
+        echo -e "    ${CHECK_MARK} ${BGreen}Skipping NextGen model import.${Color_Off}"
+        IMPORT_GAGE="no"
+    else
+        echo -e "    ${CROSS_MARK} ${BRed}Invalid input.${Color_Off}"
+    fi
+done
 
-if [[ -z "$DATA_FOLDER_PATH" ]]; then
+# Check if data path is provided as argument
+if [[ -z "$DATA_FOLDER_PATH" && $IMPORT_GAGE == "yes" ]]; then
     # If no path provided, check if we have a saved path
     if [ -f "$CONFIG_FILE" ]; then
         LAST_PATH=$(cat "$CONFIG_FILE")
@@ -660,24 +754,30 @@ if [[ -z "$DATA_FOLDER_PATH" ]]; then
 fi
 
 # Validate the directory
-if [ ! -d "$DATA_FOLDER_PATH" ]; then
+if [[ -n "$DATA_FOLDER_PATH" && ! -d "$DATA_FOLDER_PATH" ]]; then
     echo -e "${CROSS_MARK} ${BRed}Directory does not exist: $DATA_FOLDER_PATH${Color_Off}"
     exit 1
 fi
 
 print_section_header "PREPARING VISUALIZATION ENVIRONMENT"
 
-# Copy model data to visualization directory
-final_dir=$(copy_models_run "$DATA_FOLDER_PATH") || {
-    echo -e "${CROSS_MARK} ${BRed}Failed to copy model data. Exiting.${Color_Off}"
-    exit 1
-}
+# If visualization directory is non-empty, offer a fresh start option
+prompt_fresh_start
 
-# Register the model run
-add_model_run "$final_dir" || {
-    echo -e "${CROSS_MARK} ${BRed}Failed to register model run. Exiting.${Color_Off}"
-    exit 1
-}
+# If importing a model run...
+if [ -n "$DATA_FOLDER_PATH" ]; then
+    # Copy model data to visualization directory
+    final_dir=$(copy_models_run "$DATA_FOLDER_PATH") || {
+        echo -e "${CROSS_MARK} ${BRed}Failed to copy model data. Exiting.${Color_Off}"
+        exit 1
+    }
+
+    # Register the model run
+    add_model_run "$final_dir" || {
+        echo -e "${CROSS_MARK} ${BRed}Failed to register model run. Exiting.${Color_Off}"
+        exit 1
+    }
+fi
 
 # Ask what to do with ~/.datastream_ngiab
 manage_datastream_cache

--- a/viewOnTethys.sh
+++ b/viewOnTethys.sh
@@ -670,7 +670,7 @@ pause_script_execution() {
 
 
 print_usage() {
-    echo -e "${BYellow}Usage: ${BCyan}runTeehr.sh [arg ...]${Color_Off}"
+    echo -e "${BYellow}Usage: ${BCyan}viewOnTethys.sh [arg ...]${Color_Off}"
     echo -e "${BYellow}Options:${Color_Off}"
     echo -e "${BCyan}  -d [path]:${Color_Off} Designates the provided path as the data directory to import into the visualizer."
     echo -e "${BCyan}  -h:${Color_Off} Displays usage information, then exits."
@@ -698,14 +698,14 @@ while getopts 'd:hinrt:' flag; do
     FLAGS_USED=true
 done
 
-if [ -n "$DATA_FOLDER_PATH" ] && [ $IMPORT_GAGE == "no" ]; then
-    echo -e "${CROSS_MARK} ${BRed}ERROR: Flags -g and -l are incompatible.${Color_Off}"
+if [ -n "$DATA_FOLDER_PATH" ] && [ "$IMPORT_GAGE" == "no" ]; then
+    echo -e "${CROSS_MARK} ${BRed}ERROR: Flags -d and -n are incompatible.${Color_Off}"
     print_usage
     exit 1
 fi
 
 # Backwards compatibility: If no flags provided, first argument should be used as data path
-if [ $FLAGS_USED == false ] && [ -n $1 ]; then
+if [ "$FLAGS_USED" == false ] && [ -n "$1" ]; then
     DATA_FOLDER_PATH="$1"
 fi
 

--- a/viewOnTethys.sh
+++ b/viewOnTethys.sh
@@ -674,23 +674,25 @@ print_usage() {
     echo -e "${BYellow}Options:${Color_Off}"
     echo -e "${BCyan}  -d [path]:${Color_Off} Designates the provided path as the data directory to import into the visualizer."
     echo -e "${BCyan}  -h:${Color_Off} Displays usage information, then exits."
-    echo -e "${BCyan}  -i:${Color_Off} Immediately requests to import a data directory."
+    echo -e "${BCyan}  -i [image]:${Color_Off} Specifies which Docker image of the visualizer to run."
     echo -e "${BCyan}  -n:${Color_Off} Launches the visualizer immediately without importing a data directory."
     echo -e "${BCyan}  -r:${Color_Off} Retains previous console output when launching the script."
     echo -e "${BCyan}  -t [tag]:${Color_Off} Specifies which Docker image tag of the visualizer to run."
+    echo -e "${BCyan}  -y:${Color_Off} Immediately requests to import a data directory."
 }
 
 
 # Pre-script execution
-while getopts 'd:hinrt:' flag; do
+while getopts 'd:hi:nrt:y' flag; do
     case "${flag}" in
-        d) DATA_FOLDER_PATH="${OPTARG}";;
+        d) DATA_FOLDER_PATH="${OPTARG}" ;;
         h) print_usage
            exit 1 ;;
-        i) IMPORT_GAGE="yes" ;;
+        i) TETHYS_REPO="${OPTARG}" ;;
         n) IMPORT_GAGE="no";;
         r) CLEAR_CONSOLE=false ;;
         t) TETHYS_TAG="${OPTARG}" ;;
+        y) IMPORT_GAGE="yes" ;;
         *) echo -e "${CROSS_MARK} ${BRed}ERROR: Unrecognized flag.${Color_Off}"
            print_usage
            exit 1 ;;


### PR DESCRIPTION
# Updates

This PR aims to sand off some points of frustration when using NGIAB frequently, whether in development or in research.

## `viewOnTethys.sh` Changes
- `viewOnTethys.sh` now offers the user an option to *not* import a model run directory.
	- **This allows the Datastream Visualizer to be run locally** without needing a dummy NGIAB run.
- Fixed issue where `viewOnTethys.sh` would populate the visualizer configuration with duplicate entries for existing model runs.

## CLI Arguments
All helper scripts now support CLI arguments, offering several small conveniences. 

- All helper scripts
	- `-d [path]`: Specifies a path to the model run directory.
	- `-h`: Displays usage, then exits.
	- `-i [image]`: Specifies the image name. Note that this is new functionality for all helper scripts.
	- `-r`: Retains previous console output when launching the script.
	      - If set, `guide.sh` will pass this to any other scripts it launches.
	- `-t [tag]`: Specifies the image tag. Note that this is new functionality for `guide.sh`.
- `runTeehr.sh`
	- `-y`: Launches the evaluation workflow immediately, skipping the initial confirmation prompt.
- `viewOnTethys.sh`
	- `-n`: Launches the visualizer immediately without importing a data directory. Incompatible with `-d`.
	- `-y`: Immediately requests to import a data directory, skipping the new confirmation prompt. Has no effect if `-d` is used.
- As a side effect of these changes, `guide.sh` now automatically passes directory paths to the TEEHR and Tethys scripts.

*Note that these changes retain backwards compatibility with the existing data directory argument in viewOnTethys.sh and runTeehr.sh. However, this argument will only be read if flags are not present.*

## Other changes
- All helper scripts: Fixed off-by-one error in the function for rendering section headers.
- `guide.sh`: Now correctly passes data directories to the TEEHR and Tethys scripts.
- `guide.sh`: Now passes `-y` when running the TEEHR script.
      - Fixes an issue where the user was asked if they wanted to run a TEEHR evaluation twice.
- `viewOnTethys.sh`: Updated welcome banner to match other guide scripts.
- `HelloNGEN.sh`: Improved clarity regarding the interactive bash shell.

# Testing

**MacOS likely still needs testing.** This PR's contents were tested top-to-bottom on WSL, which means that it should all work smoothly on Linux as well.
