### PR TITLE
Burn lstm

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -169,7 +169,7 @@ FROM build_base AS lstm_weights
 RUN git clone --depth=1 --branch example_weights https://github.com/ciroh-ua/lstm.git /lstm_weights
 # add the rust weight conversion
 RUN uv run --with pyyaml --with numpy --with torch --extra-index-url https://download.pytorch.org/whl/cpu \
-    https://raw.githubusercontent.com/CIROH-UA/bmi-burn-lstm/refs/heads/main/scripts/convert.py \
+    https://raw.githubusercontent.com/CIROH-UA/rust-lstm-1025/refs/tags/v0.1.0/scripts/convert.py \
     all /lstm_weights/trained_neuralhydrology_models/
 # replace the relative path with the absolute path in the model config files
 RUN shopt -s globstar
@@ -182,8 +182,8 @@ WORKDIR /build
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
 RUN git clone --depth=1 https://github.com/aaraney/bmi-rs
-RUN git clone --depth=1 https://github.com/ciroh-ua/bmi-burn-lstm
-WORKDIR /build/bmi-burn-lstm
+RUN git clone --depth=1 --branch v0.1.0 https://github.com/ciroh-ua/rust-lstm-1025
+WORKDIR /build/rust-lstm-1025
 RUN cargo build --release
 
 FROM base AS final
@@ -227,7 +227,7 @@ RUN rm -rf /ngen/ngen/extern/lstm/trained_neuralhydrology_models
 COPY --from=lstm_weights /lstm_weights/trained_neuralhydrology_models /ngen/ngen/extern/lstm/trained_neuralhydrology_models
 
 # Copy the rust version of the lstm over.
-COPY --from=burn_lstm /build/bmi-burn-lstm/target/release/libbmi_burn_lstm.so /dmod/shared_libs/libbmi_burn_lstm.so
+COPY --from=burn_lstm /build/rust-lstm-1025/target/release/librust_lstm_1025.so /dmod/shared_libs/librust_lstm_1025.so
 
 ## add some metadata to the image
 COPY --from=troute_build /tmp/troute_url /ngen/troute_url


### PR DESCRIPTION
Adds the new rust lstm implementation from https://github.com/ciroh-ua/rust-lstm-1025

This is functionally a drop in replacement for ciroh-ua/lstm. The pytorch weights need to be converted for this version of the lstm to be able to import them. I've done it here in the docker image to save the ~4s of conversion time on each run. Without the weight conversion in here, the model will convert them automatically when it's run.

## Changes:
* moved the .cargo path update and uv install to the base layer as it's needed by cargo to compile the rust lstm
* removed boost compilation (`./b2`) to speed up docker build. we only need the headers to compile ngen

## Testing:
I pushed a test image called joshcu/ngiab:burn_lstm
I've run this a bunch of times with different inputs and get near identical results out with a much quicker execution time.
The current version of the preprocessor suports `--lstm_rust` to create the rust config which is just a different realization.json. [python](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/main/modules/data_sources/lstm-realization-template.json) vs [rust](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/main/modules/data_sources/lstm-rust-realization-template.json) 

```json
# A real realization.json would only have either one module or the other
"modules": [
# rust module looks like this
            {
              "name": "bmi_c",
              "params": {
                "name": "bmi_c",
                "model_type_name": "bmi_rust",
                "init_config": "./config/cat_config/lstm/{{id}}.yml",
                "allow_exceed_end_time": true,
                "main_output_variable": "land_surface_water__runoff_depth",
                "uses_forcing_file": false,
                "registration_function": "register_bmi_lstm",
                "library_file": "/dmod/shared_libs/librust_lstm_1025.so"
              }
            },
# python module looks like this
             {
              "name": "bmi_python",
              "params": {
                "name": "bmi_python",
                "python_type": "lstm.bmi_lstm.bmi_LSTM",
                "model_type_name": "bmi_lstm",
                "init_config": "./config/cat_config/lstm/{{id}}.yml",
                "allow_exceed_end_time": true,
                "main_output_variable": "land_surface_water__runoff_depth",
                "uses_forcing_file": false
              }
            }
          ]
```


```bash
uvx ngiab-prep -i gage-10154200 -o ngiab_test --start 2010-01-01 --end 2015-01-01 -sfr --lstm_rust --source aorc
docker run --rm -it -v "/home/josh/ngiab_preprocess_output/ngiab_test:/ngen/ngen/data" joshcu/ngiab:burn_lstm /ngen/ngen/data
# rust lstm
NGen top-level timings:
	NGen::init: 1.22347
	NGen::simulation: 30.7947
	NGen::routing: 8.50149
Run completed successfully, exiting, have a nice day!
```

To run the python
    
```bash
uvx ngiab-prep -i gage-10154200 -o ngiab_test --start 2010-01-01 --end 2015-01-01 -sfr --lstm --source aorc
# python lstm
NGen top-level timings:
	NGen::init: 1.93903
	NGen::simulation: 155.537
	NGen::routing: 8.93595
Run completed successfully, exiting, have a nice day!
```
The outputs aren't exactly identical, but they're very close. A few numbers are rounded differently every now and then which is small enough to not matter.
<img width="1265" height="933" alt="image" src="https://github.com/user-attachments/assets/6f5728cd-2ad3-4778-bf3c-1c62e2f83f3b" />
 