### PR TITLE
Update Boost C++ libraries to 1.86.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,11 +36,11 @@ RUN dnf install -y epel-release && \
 
 
 FROM build_base AS boost_build
-RUN wget https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.gz
-RUN tar -xzf boost_1_79_0.tar.gz
-WORKDIR /boost_1_79_0
+RUN wget https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz
+RUN tar -xzf boost_1_86_0.tar.gz
+WORKDIR /boost_1_86_0
 RUN ./bootstrap.sh && ./b2 headers
-ENV BOOST_ROOT=/boost_1_79_0
+ENV BOOST_ROOT=/boost_1_86_0
 
 
 


### PR DESCRIPTION
Addresses issue https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/355, ensuring continued `ngen` compatibility.
In theory, should have no functional impact beyond maintaining upstream compatibility.

## Updates
- Updates Boost C++ libraries to 1.86.0, 

## Testing 
Tested and confirmed working on x86 Windows via WSL. Since this affects the build process within the container, these changes should hopefully be OS-independent.

Testing on an ARM-based device would likely be advisable since this is a compiler-focused change.

*(EDIT: GitHub actions on this PR are actually working right now thanks to a cached copy of `rust-lstm` on the build runner. This may break if the cache gets invalidated. See my original comments on this below.)*
> Note that the image currently fails to build due to an upstream issue (https://github.com/CIROH-UA/rust-lstm/issues/1). As such, Dockerfile operations related to `rust-lstm` were commented out during testing, and GitHub Actions on this PR will likely fail until https://github.com/CIROH-UA/rust-lstm/pull/2 is merged. From what I can tell, the Boost C++ libraries aren't involved in the compiler toolchain for `rust-lstm`, so this omission from testing shouldn't cause any problems.
