### PR TITLE
update lstm version to fix build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN dnf install -y epel-release && \
     python3 python3-devel python3-pip \
     expat-devel flex bison udunits2-devel zlib-devel \
     wget mpich-devel hdf5-devel netcdf-devel \
-    netcdf-fortran-devel netcdf-cxx-devel lld
+    netcdf-fortran-devel netcdf-cxx-devel lld clang
 
 
 
@@ -181,8 +181,7 @@ RUN dnf install -y clang
 WORKDIR /build
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
-RUN git clone --depth=1 https://github.com/aaraney/bmi-rs
-RUN git clone --depth=1 --branch v0.1.0 https://github.com/ciroh-ua/rust-lstm-1025
+RUN git clone --depth=1 --branch v0.1.2 https://github.com/ciroh-ua/rust-lstm-1025
 WORKDIR /build/rust-lstm-1025
 RUN cargo build --release
 
@@ -235,4 +234,4 @@ COPY --from=ngen_build /tmp/ngen_url /ngen/ngen_url
 
 RUN echo "export PS1='\u\[\033[01;32m\]@ngiab_dev\[\033[00m\]:\[\033[01;35m\]\W\[\033[00m\]\$ '" >> ~/.bashrc
 
-ENTRYPOINT ["./HelloNGEN.sh"]
+ENTRYPOINT ["/ngen/HelloNGEN.sh"]


### PR DESCRIPTION
closes #364 

Updates the lstm to the fixed version. 

additional work was needed
https://github.com/CIROH-UA/rust-lstm/commit/5e1e74cb5a28178c9d68db6c0a00fe4869c6a18a
https://github.com/JoshCu/bmi-rs/commit/09d77d950a68dc3022c0c75640a643230e864772

## HPC
updating the entrypoint to an absolute path also means this docker image works on hpc
```bash
uvx ngiab-prep -i gage-10154200 --start 2010-01-01 --end 2010-01-10 -sfr --lstm_rust --source aorc
singularity pull docker://joshcu/ngiab
singularity run --workdir /ngen/  --bind $HOME/ngiab_preprocess_output/gage-10154200:/ngen/ngen/data ngiab_latest.sif /ngen/ngen/data
```



