### PR TITLE
add rust-lstm to model docs

### DIFF
--- a/docs/03_04_MODELS.md
+++ b/docs/03_04_MODELS.md
@@ -55,7 +55,14 @@ Library file path: `/dmod/shared_libs/libtopmodelbmi.so.1.0.0`
 LSTM networks are a type of recurrent neural network used in deep learning.
 This LSTM module is specifically tailored for generalized streamflow prediction within CONUS.
 
-Python class: `lstm.bmi_LSTM` <!-- TODO: verify -->
+Python class: `lstm.bmi_lstm.bmi_LSTM`
+
+## Rust LSTM
+
+> *GitHub: [CIROH-UA/rust-lstm](https://github.com/CIROH-UA/rust-lstm)*
+> *Developed / maintained by [Josh Cunningham](https://github.com/JoshCu)*
+
+A Rust implementation of the python lstm BMI (Basic Model Interface) adapter. Provides a drop-in replacement for the implementations found in [CIROH-UA/lstm](https://github.com/CIROH-UA/lstm), [NOAA-OWP/lstm](https://github.com/NOAA-OWP/lstm), and [jmframe/lstm](https://github.com/jmframe/lstm).
 
 ## Soil Moisture Profiles
 


### PR DESCRIPTION
adds rust lstm to the docs.

we could also update the developer / maintainer to "CIROH Science team" if that's better