### PR TITLE
put CASAM's van Genuchton params into dmod/shared_datasets/static

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,7 +134,7 @@ RUN dnf install -y netcdf-cxx4-mpich-devel
 RUN cmake -G Ninja -B cmake_build_parallel -S . ${COMMON_BUILD_ARGS} ${MPI_BUILD_ARGS} \
     -DNetCDF_CXX_INCLUDE_DIR=/usr/include/mpich-$(arch) \
     -DNetCDF_INCLUDE_DIR=/usr/include/mpich-$(arch) && \
-    cmake --build cmake_build_parallel --target all -- -j 4
+    cmake --build cmake_build_parallel --target all -- -j $(nproc)
 
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,7 +134,7 @@ RUN dnf install -y netcdf-cxx4-mpich-devel
 RUN cmake -G Ninja -B cmake_build_parallel -S . ${COMMON_BUILD_ARGS} ${MPI_BUILD_ARGS} \
     -DNetCDF_CXX_INCLUDE_DIR=/usr/include/mpich-$(arch) \
     -DNetCDF_INCLUDE_DIR=/usr/include/mpich-$(arch) && \
-    cmake --build cmake_build_parallel --target all -- -j $(nproc)
+    cmake --build cmake_build_parallel --target all -- -j 4
 
 
 
@@ -177,6 +177,7 @@ RUN mkdir -p /dmod/datasets /dmod/datasets/static /dmod/shared_libs /dmod/bin /d
     shopt -s globstar && \
     cp -a ./extern/**/cmake_build/*.so* /dmod/shared_libs/. || true && \
     cp -a ./extern/noah-owp-modular/**/*.TBL /dmod/datasets/static && \
+    cp -a ./extern/lgar-c/LGAR-C/data/vG_default_params.dat /dmod/datasets/static && \
     cp -a ./cmake_build_parallel/ngen /dmod/bin/ngen-parallel || true && \
     cp -a ./cmake_build_serial/ngen /dmod/bin/ngen-serial || true && \
     cp -a ./cmake_build_parallel/partitionGenerator /dmod/bin/partitionGenerator || true && \


### PR DESCRIPTION
Places CASAM's van Genuchton parameters into `/dmod/shared_datasets/static`.  Required for #472 

## Additions

- Adds van Genucton parameters to NGIAB image

## Testing 
### Method
Tested with this hand-generated data package: 
[cat-1555522.zip](https://github.com/user-attachments/files/29751695/cat-1555522.zip)
Note that https://github.com/CIROH-UA/ngen/pull/35 will need to be merged as well for CASAM to be built correctly. Alternatively, if you want to test this out locally before the ngen update goes through, you can change the `ngen` branch to be `casam`


## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)

## Testing checklist

### Target Environment support

- [ ] Windows (wsl)
- [X] Linux
- [X] MaxOs (apple silicon)

